### PR TITLE
D1 sessions

### DIFF
--- a/api/src/base.mts
+++ b/api/src/base.mts
@@ -28,7 +28,8 @@ export async function verifyToken(token: string, c: Context<{ Bindings: EnvVars;
 
 			return Promise.all([import('~shared/db-preview/schemas/root'), import('drizzle-orm')])
 				.then(([{ api_keys_tenants, tenants }, { eq, sql }]) =>
-					c.var.r_db
+					c.var
+						.r_db()
 						.select({
 							expires: api_keys_tenants.expires,
 							t_id: tenants.t_id,
@@ -68,8 +69,7 @@ export async function verifyToken(token: string, c: Context<{ Bindings: EnvVars;
 							c.set('t_id', row.t_id);
 							c.set('t_d1_id', row.d1_id);
 							await import('~shared/db-core/db.mjs').then(({ DBManager }) =>
-								c.set(
-									't_db',
+								c.set('t_db', () =>
 									DBManager.getDrizzle(
 										{
 											accountId: c.env.CF_ACCOUNT_ID,
@@ -88,14 +88,17 @@ export async function verifyToken(token: string, c: Context<{ Bindings: EnvVars;
 									const potentialVipBinding = (await CryptoHelpers.getHash('SHA-256', `t_${row.t_id.utf8}${c.env.NODE_ENV !== 'production' && '_p'}`)).toUpperCase();
 
 									if (potentialVipBinding in c.env) {
-										await import('~shared/db-core/db.mjs').then(({ DBManager }) => c.set('t_db', DBManager.getDrizzle(c.env[potentialVipBinding] as D1Database, { logger: c.env.NODE_ENV !== 'production' })));
+										if (!c.var.t_db_session) c.set('t_db_session', (c.env[potentialVipBinding] as D1Database).withSession('first-unconstrained'));
+
+										await import('~shared/db-core/db.mjs').then(({ DBManager }) => c.set('t_db', () => DBManager.getDrizzle((c.env[potentialVipBinding] as D1Database).withSession(c.var.t_db_session.getBookmark() ?? 'first-unconstrained'), { logger: c.env.NODE_ENV !== 'production' })));
 									}
 								}
 							});
 
 							return Promise.all([import('~shared/db-preview/schemas/tenant'), import('drizzle-orm')])
 								.then(([{ api_keys }, { eq, sql }]) =>
-									c.var.t_db
+									c.var
+										.t_db()
 										.select({
 											hash: api_keys.hash,
 											r_keyrings: api_keys.r_keyrings,
@@ -150,7 +153,8 @@ export async function verifyToken(token: string, c: Context<{ Bindings: EnvVars;
 									if (!expired && hashCheck) {
 										await Promise.all([import('~shared/db-preview/schemas/tenant'), import('drizzle-orm')])
 											.then(([{ api_keys, keyrings, api_keys_keyrings }, { eq, sql }]) =>
-												c.var.t_db
+												c.var
+													.t_db()
 													.select({
 														kr_id: api_keys_keyrings.kr_id,
 														kr_name: keyrings.name,

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -46,14 +46,11 @@ export default class extends WorkerEntrypoint<EnvVars> {
 		app.use('*', async (c, next) => {
 			c.set('bodyClone', secondaryRequest);
 
-			await next();
-		});
-		app.use('*', async (c, next) =>
-			Promise.all([import('@chainfuse/helpers/common'), import('~shared/db-core/db.mjs')]).then(async ([{ Helpers }, { DBManager }]) => {
+			c.set('r_db_session', c.env.EAAS_ROOT.withSession('first-unconstrained'));
+			await Promise.all([import('@chainfuse/helpers/common'), import('~shared/db-core/db.mjs')]).then(async ([{ Helpers }, { DBManager }]) => {
 				if (Helpers.isLocal(c.env.CF_VERSION_METADATA)) {
 					await import('~shared/db-core/db.mjs').then(({ StaticDatabase }) =>
-						c.set(
-							'r_db',
+						c.set('r_db', () =>
 							DBManager.getDrizzle(
 								{
 									accountId: c.env.CF_ACCOUNT_ID,
@@ -67,12 +64,12 @@ export default class extends WorkerEntrypoint<EnvVars> {
 						),
 					);
 				} else {
-					c.set('r_db', DBManager.getDrizzle(c.env.EAAS_ROOT, { logger: c.env.NODE_ENV !== 'production' }));
+					c.set('r_db', () => DBManager.getDrizzle(c.env.EAAS_ROOT.withSession(c.var.r_db_session.getBookmark() ?? 'first-unconstrained'), { logger: c.env.NODE_ENV !== 'production' }));
 				}
+			});
 
-				await next();
-			}),
-		);
+			await next();
+		});
 
 		await Promise.all([import('@hono/zod-validator'), import('zod')]).then(([{ zValidator }, { z }]) =>
 			app.use(

--- a/api/src/types.mts
+++ b/api/src/types.mts
@@ -32,11 +32,13 @@ interface VipBindingsPreview {
 
 export interface ContextVariables extends TimingVariables {
 	bodyClone: ReturnType<Parameters<Exclude<WorkerEntrypoint['fetch'], undefined>>[0]['clone']>;
-	r_db: ReturnType<typeof DBManager.getDrizzle>;
+	r_db_session: D1DatabaseSession;
+	r_db: () => ReturnType<typeof DBManager.getDrizzle>;
 
 	t_id: UuidExport;
 	t_d1_id: UuidExport;
-	t_db: ReturnType<typeof DBManager.getDrizzle>;
+	t_db_session: D1DatabaseSession;
+	t_db: () => ReturnType<typeof DBManager.getDrizzle>;
 
 	ak_id: UuidExport;
 	globalPermissions?: {

--- a/api/src/v0/apikeys/list.mts
+++ b/api/src/v0/apikeys/list.mts
@@ -40,7 +40,8 @@ export const route = await Promise.all([import('@hono/zod-openapi'), import('~/v
 app.openapi(route, async (c) =>
 	Promise.all([import('~shared/db-preview/schemas/tenant'), import('~shared/types/d1/index.mjs'), import('drizzle-orm')])
 		.then(([{ api_keys }, { Permissions }, { eq, sql }]) =>
-			c.var.t_db
+			c.var
+				.t_db()
 				.select({
 					token_id: api_keys.ak_id,
 					name: api_keys.name,

--- a/api/src/v0/apikeys/specific.mts
+++ b/api/src/v0/apikeys/specific.mts
@@ -64,7 +64,8 @@ app.openapi(route, (c) => {
 					if (hasPermission) {
 						return Promise.all([import('~shared/db-preview/schemas/tenant'), import('drizzle-orm')])
 							.then(([{ api_keys }, { eq, sql }]) =>
-								c.var.t_db
+								c.var
+									.t_db()
 									.select({
 										token_id: api_keys.ak_id,
 										name: api_keys.name,

--- a/api/src/v0/encrypt.mts
+++ b/api/src/v0/encrypt.mts
@@ -489,7 +489,8 @@ app.openapi(embededRoute, async (c) => {
 
 			// Efficient batch retreive datakeys
 			startTime(c, 'db-fetch-datakeys');
-			const receivedDatakeys = await c.var.t_db
+			const receivedDatakeys = await c.var
+				.t_db()
 				.select({
 					dk_id: datakeys.dk_id,
 					kr_id: datakeys.kr_id,
@@ -624,7 +625,8 @@ app.openapi(embededRoute, async (c) => {
 											 * @link https://github.com/cloudflare/workers-sdk/issues/2733
 											 */
 											c.executionCtx.waitUntil(
-												c.var.t_db
+												c.var
+													.t_db()
 													.select({ generation_count: datakeys.generation_count })
 													.from(datakeys)
 													.where(eq(datakeys.dk_id, sql`unhex(${bwKey.dk_id.hex})`))
@@ -642,7 +644,8 @@ app.openapi(embededRoute, async (c) => {
 													.then(([row]) => {
 														if (row) {
 															return import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) =>
-																c.var.t_db
+																c.var
+																	.t_db()
 																	.update(datakeys)
 																	.set({
 																		generation_count: sql`unhex(${BufferHelpers.bigintToHex(++row.generation_count)})`,
@@ -696,7 +699,8 @@ app.openapi(embededRoute, async (c) => {
 			const kr_id = await import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) => BufferHelpers.uuidConvert(kr_id_base64url));
 
 			startTime(c, 'db-fetch-datakeys');
-			const receivedDatakeys = await c.var.t_db
+			const receivedDatakeys = await c.var
+				.t_db()
 				.select({
 					dk_id: datakeys.dk_id,
 					kr_id: datakeys.kr_id,
@@ -819,7 +823,8 @@ app.openapi(embededRoute, async (c) => {
 									 * @link https://github.com/cloudflare/workers-sdk/issues/2733
 									 */
 									c.executionCtx.waitUntil(
-										c.var.t_db
+										c.var
+											.t_db()
 											.select({ generation_count: datakeys.generation_count })
 											.from(datakeys)
 											.where(eq(datakeys.dk_id, sql`unhex(${bwKey.dk_id.hex})`))
@@ -837,7 +842,8 @@ app.openapi(embededRoute, async (c) => {
 											.then(([row]) => {
 												if (row) {
 													return import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) =>
-														c.var.t_db
+														c.var
+															.t_db()
 															.update(datakeys)
 															.set({
 																generation_count: sql`unhex(${BufferHelpers.bigintToHex(++row.generation_count)})`,
@@ -959,7 +965,8 @@ app.openapi(uploadedRoute, async (c) => {
 		const kr_id = await import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) => BufferHelpers.uuidConvert(kr_id_base64url));
 
 		startTime(c, 'db-fetch-datakeys');
-		const receivedDatakeys = await c.var.t_db
+		const receivedDatakeys = await c.var
+			.t_db()
 			.select({
 				dk_id: datakeys.dk_id,
 				kr_id: datakeys.kr_id,
@@ -1102,7 +1109,8 @@ app.openapi(uploadedRoute, async (c) => {
 				 * @link https://github.com/cloudflare/workers-sdk/issues/2733
 				 */
 				c.executionCtx.waitUntil(
-					c.var.t_db
+					c.var
+						.t_db()
 						.select({ generation_count: datakeys.generation_count })
 						.from(datakeys)
 						.where(eq(datakeys.dk_id, sql`unhex(${bwKey.dk_id.hex})`))
@@ -1120,7 +1128,8 @@ app.openapi(uploadedRoute, async (c) => {
 						.then(([row]) => {
 							if (row) {
 								return import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) =>
-									c.var.t_db
+									c.var
+										.t_db()
 										.update(datakeys)
 										.set({
 											generation_count: sql`unhex(${BufferHelpers.bigintToHex(row.generation_count + BigInt(returningCiphertexts.length))})`,

--- a/api/src/v0/keyrings/create.mts
+++ b/api/src/v0/keyrings/create.mts
@@ -53,7 +53,8 @@ app.openapi(route, (c) => {
 
 	return Promise.all([import('~shared/db-preview/schemas/tenant'), import('drizzle-orm'), import('@chainfuse/helpers/buffers')]).then(([{ keyrings }, { sql }, { BufferHelpers }]) =>
 		BufferHelpers.generateUuid.then((kr_id) =>
-			c.var.t_db
+			c.var
+				.t_db()
 				.insert(keyrings)
 				.values({
 					kr_id: sql`unhex(${kr_id.hex})`,

--- a/api/src/v0/keyrings/list.mts
+++ b/api/src/v0/keyrings/list.mts
@@ -30,7 +30,8 @@ app.openapi(route, async (c) => {
 	if ((c.var.globalPermissions && c.var.globalPermissions.r_keyrings > 0) || kr_ids.length > 0) {
 		return Promise.all([import('~shared/db-preview/schemas/tenant'), import('~shared/types/d1/index.mjs'), import('drizzle-orm')])
 			.then(([{ keyrings }, { Permissions }, { inArray, sql }]) =>
-				c.var.t_db
+				c.var
+					.t_db()
 					.select({
 						kr_id: keyrings.kr_id,
 						name: keyrings.name,
@@ -73,7 +74,8 @@ app.openapi(route, async (c) => {
 						Promise.all([
 							import('cron-schedule'),
 							Promise.all([import('~shared/db-preview/schemas/tenant'), import('drizzle-orm')]).then(([{ datakeys }, { eq, sql, desc }]) =>
-								c.var.t_db
+								c.var
+									.t_db()
 									.select({
 										generation_count: datakeys.generation_count,
 									})


### PR DESCRIPTION
This pull request refactors database session management and access patterns across multiple files in the `api` module. The changes introduce lazy initialization for database access methods (`r_db` and `t_db`) and add session handling to improve efficiency and flexibility. Additionally, the `ContextVariables` interface is updated to reflect these changes.

### Database session management refactor:

* [`api/src/base.mts`](diffhunk://#diff-d2b8e8ed091d10f23ffab5956501ab8d03f8498679143ae31b06aca9fe317ba3L31-R32): Updated `verifyToken` function to use lazy initialization (`t_db()` and `r_db()`) for database access and added session handling for tenant-specific and VIP bindings. [[1]](diffhunk://#diff-d2b8e8ed091d10f23ffab5956501ab8d03f8498679143ae31b06aca9fe317ba3L31-R32) [[2]](diffhunk://#diff-d2b8e8ed091d10f23ffab5956501ab8d03f8498679143ae31b06aca9fe317ba3L71-R72) [[3]](diffhunk://#diff-d2b8e8ed091d10f23ffab5956501ab8d03f8498679143ae31b06aca9fe317ba3L91-R101) [[4]](diffhunk://#diff-d2b8e8ed091d10f23ffab5956501ab8d03f8498679143ae31b06aca9fe317ba3L153-R157)
* [`api/src/index.ts`](diffhunk://#diff-c7daeed68470fce500b64961dc1986f90d3c903d7679f553701de7aed7aa72a6L49-R53): Refactored `WorkerEntrypoint` to initialize `r_db_session` and use lazy initialization for `r_db` with session bookmarks. [[1]](diffhunk://#diff-c7daeed68470fce500b64961dc1986f90d3c903d7679f553701de7aed7aa72a6L49-R53) [[2]](diffhunk://#diff-c7daeed68470fce500b64961dc1986f90d3c903d7679f553701de7aed7aa72a6L70-R72)

### Interface updates:

* [`api/src/types.mts`](diffhunk://#diff-88d75126b24972afab033b9fb6c4c4ddfec79d6cabfd87572da6fea02322bf65L35-R41): Modified `ContextVariables` to include session objects (`r_db_session`, `t_db_session`) and changed `r_db` and `t_db` to functions for lazy initialization.

### Lazy database access implementation:

* Various route handlers (`api/src/v0/*`): Replaced direct database access (`t_db`) with lazy initialization (`t_db()`) to ensure consistent session handling and improve maintainability. [[1]](diffhunk://#diff-5cda2971c2f1fa637592a9bf52afad5e71d49a1333ec24d5de4f4d45cc0e44a7L43-R44) [[2]](diffhunk://#diff-8c5adf906cacf2d9ccaf117f58d06d9dd50bad8d92629bd37a22db681c8f16c4L67-R68) [[3]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL492-R493) [[4]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL627-R629) [[5]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL645-R648) [[6]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL699-R703) [[7]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL822-R827) [[8]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL840-R846) [[9]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL962-R969) [[10]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL1105-R1113) [[11]](diffhunk://#diff-07307547e4c2b137d416143196ba20d47f282594eae285360db19feea88b79baL1123-R1132) [[12]](diffhunk://#diff-285fa3fa7a8896cbbcbd73d578b5e1883ba8eef0f32bd8b9f5ccd73e4dcae2b9L56-R57) [[13]](diffhunk://#diff-99ea9ea67fc5da4ac244d4445bd49e71bc9929ac393c3787e53fbb9cd3b17630L33-R34) [[14]](diffhunk://#diff-99ea9ea67fc5da4ac244d4445bd49e71bc9929ac393c3787e53fbb9cd3b17630L76-R78)