### PR TITLE
Normalize api keys

### DIFF
--- a/api/src/v0/apikeys/list.mts
+++ b/api/src/v0/apikeys/list.mts
@@ -1,6 +1,7 @@
 import type { z } from '@hono/zod-openapi';
 import type { ContextVariables, EnvVars } from '~/types.mjs';
 import type { apikeyOutput } from '~/v0/apikeys/shared.mjs';
+import type { Permissions } from '~shared/types/d1/index.mjs';
 
 const app = await import('@hono/zod-openapi').then(({ OpenAPIHono }) => new OpenAPIHono<{ Bindings: EnvVars; Variables: ContextVariables }>());
 
@@ -39,37 +40,99 @@ export const route = await Promise.all([import('@hono/zod-openapi'), import('~/v
 
 app.openapi(route, async (c) =>
 	Promise.all([import('~shared/db-preview/schemas/tenant'), import('~shared/types/d1/index.mjs'), import('drizzle-orm')])
-		.then(([{ api_keys }, { Permissions }, { eq, sql }]) =>
-			c.var
-				.t_db()
-				.select({
-					token_id: api_keys.ak_id,
-					name: api_keys.name,
-					b_time: api_keys.b_time,
-					m_time: api_keys.m_time,
-					expires: api_keys.expires,
-					c_time: api_keys.c_time,
-				})
-				.from(api_keys)
-				.where(c.var.globalPermissions?.r_apikeys === Permissions.None ? eq(api_keys.ak_id, sql`unhex(${c.var.ak_id.hex})`) : undefined),
+		.then(([{ api_keys, api_keys_keyrings, keyrings }, { Permissions }, { eq, sql }]) =>
+			c.var.t_db().batch([
+				c.var
+					.t_db()
+					.select({
+						token_id: api_keys.ak_id,
+						name: api_keys.name,
+						b_time: api_keys.b_time,
+						m_time: api_keys.m_time,
+						expires: api_keys.expires,
+						c_time: api_keys.c_time,
+						r_apikeys: api_keys.r_apikeys,
+						r_keyrings: api_keys.r_keyrings,
+					})
+					.from(api_keys)
+					.where(c.var.globalPermissions?.r_apikeys === Permissions.None ? eq(api_keys.ak_id, sql`unhex(${c.var.ak_id.hex})`) : undefined),
+				c.var
+					.t_db()
+					.select({
+						ak_id: api_keys_keyrings.ak_id,
+						keyring_name: keyrings.name,
+						r_datakeys: api_keys_keyrings.r_datakeys,
+						r_encrypt: api_keys_keyrings.r_encrypt,
+						r_decrypt: api_keys_keyrings.r_decrypt,
+						r_rewrap: api_keys_keyrings.r_rewrap,
+						r_sign: api_keys_keyrings.r_sign,
+						r_verify: api_keys_keyrings.r_verify,
+						r_hmac: api_keys_keyrings.r_hmac,
+					})
+					.from(api_keys_keyrings)
+					.innerJoin(keyrings, eq(api_keys_keyrings.kr_id, keyrings.kr_id))
+					.where(c.var.globalPermissions?.r_apikeys === Permissions.None ? eq(api_keys_keyrings.ak_id, sql`unhex(${c.var.ak_id.hex})`) : undefined),
+			]),
 		)
-		.then((rows) =>
-			import('~shared/types/d1/index.mjs').then(({ Permissions }) =>
-				rows.map(
+		.then(([apiKeyRows, keyringRows]) =>
+			import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) =>
+				Promise.all([
+					Promise.all(
+						apiKeyRows.map(async (row) => ({
+							...row,
+							token_id: await BufferHelpers.uuidConvert(row.token_id),
+						})),
+					),
+					Promise.all(
+						keyringRows.map(async (row) => ({
+							...row,
+							ak_id: await BufferHelpers.uuidConvert(row.ak_id),
+						})),
+					),
+				]).then(([apiKeyRows, keyringRows]) => ({ apiKeyRows, keyringRows })),
+			),
+		)
+		.then(({ apiKeyRows, keyringRows }) =>
+			import('~shared/types/d1/index.mjs').then(({ Permissions }) => {
+				// Group keyring permissions by API key ID
+				const keyringsByApiKey = new Map<string, Record<string, any>>();
+				for (const keyringRow of keyringRows) {
+					if (!keyringRow.keyring_name) continue;
+
+					const apiKeyId = keyringRow.ak_id.base64url;
+					if (!keyringsByApiKey.has(apiKeyId)) {
+						keyringsByApiKey.set(apiKeyId, {});
+					}
+
+					keyringsByApiKey.get(apiKeyId)![keyringRow.keyring_name] = {
+						r_datakeys: Permissions[keyringRow.r_datakeys] as unknown as Permissions,
+						r_encrypt: keyringRow.r_encrypt,
+						r_decrypt: keyringRow.r_decrypt,
+						r_rewrap: keyringRow.r_rewrap,
+						r_sign: keyringRow.r_sign,
+						r_verify: keyringRow.r_verify,
+						r_hmac: keyringRow.r_hmac,
+					};
+				}
+
+				return apiKeyRows.map(
 					(row) =>
 						({
-							token_id: Buffer.from(row.token_id).toString('base64url'),
-							name: row.name,
 							created: row.b_time,
-							lastRotation: row.m_time,
-							expires: row.expires,
 							expired: new Date(row.expires) < new Date(),
+							expires: row.expires,
 							lastModified: row.c_time,
-							keyringsPermission: Permissions[c.var.globalPermissions!.r_keyrings],
-							apikeysPermission: Permissions[c.var.globalPermissions!.r_apikeys],
-						}) satisfies z.infer<typeof apikeyOutput>,
-				),
-			),
+							lastRotation: row.m_time,
+							name: row.name,
+							token_id: row.token_id.base64url,
+							// It's the string version
+							apikeysPermission: Permissions[row.r_apikeys] as unknown as Permissions,
+							// It's the string version
+							keyringsPermission: Permissions[row.r_keyrings] as unknown as Permissions,
+							keyrings: keyringsByApiKey.get(row.token_id.base64url) ?? {},
+						}) satisfies z.output<typeof apikeyOutput>,
+				);
+			}),
 		)
 		.then((json) => c.json(json)),
 );

--- a/api/src/v0/apikeys/specific.mts
+++ b/api/src/v0/apikeys/specific.mts
@@ -1,6 +1,7 @@
 import type { z } from '@hono/zod-openapi';
 import type { ContextVariables, EnvVars } from '~/types.mjs';
 import type { apikeyOutput } from '~/v0/apikeys/shared.mjs';
+import type { Permissions } from '~shared/types/d1/index.mjs';
 
 const app = await import('@hono/zod-openapi').then(({ OpenAPIHono }) => new OpenAPIHono<{ Bindings: EnvVars; Variables: ContextVariables }>());
 
@@ -62,33 +63,54 @@ app.openapi(route, (c) => {
 				})
 				.then((hasPermission) => {
 					if (hasPermission) {
-						return Promise.all([import('~shared/db-preview/schemas/tenant'), import('drizzle-orm')])
-							.then(([{ api_keys }, { eq, sql }]) =>
-								c.var
-									.t_db()
-									.select({
-										token_id: api_keys.ak_id,
-										name: api_keys.name,
-										b_time: api_keys.b_time,
-										m_time: api_keys.m_time,
-										expires: api_keys.expires,
-										c_time: api_keys.c_time,
-									})
-									.from(api_keys)
-									.where(eq(api_keys.ak_id, sql`unhex(${ak_id.hex})`))
-									.limit(1),
+						return Promise.all([import('~shared/db-preview/schemas/tenant'), import('~shared/types/d1/index.mjs'), import('drizzle-orm')])
+							.then(([{ api_keys, api_keys_keyrings, keyrings }, { Permissions }, { eq, sql }]) =>
+								c.var.t_db().batch([
+									c.var
+										.t_db()
+										.select({
+											token_id: api_keys.ak_id,
+											name: api_keys.name,
+											b_time: api_keys.b_time,
+											m_time: api_keys.m_time,
+											expires: api_keys.expires,
+											c_time: api_keys.c_time,
+											r_apikeys: api_keys.r_apikeys,
+											r_keyrings: api_keys.r_keyrings,
+										})
+										.from(api_keys)
+										.where(eq(api_keys.ak_id, sql`unhex(${c.var.ak_id.hex})`))
+										.limit(1),
+									c.var
+										.t_db()
+										.select({
+											keyring_name: keyrings.name,
+											r_datakeys: api_keys_keyrings.r_datakeys,
+											r_encrypt: api_keys_keyrings.r_encrypt,
+											r_decrypt: api_keys_keyrings.r_decrypt,
+											r_rewrap: api_keys_keyrings.r_rewrap,
+											r_sign: api_keys_keyrings.r_sign,
+											r_verify: api_keys_keyrings.r_verify,
+											r_hmac: api_keys_keyrings.r_hmac,
+										})
+										.from(api_keys_keyrings)
+										.innerJoin(keyrings, eq(api_keys_keyrings.kr_id, keyrings.kr_id))
+										.where(eq(api_keys_keyrings.ak_id, sql`unhex(${c.var.ak_id.hex})`)),
+								]),
 							)
-							.then((rows) =>
+							.then(([apiKeyRows, keyringRows]) =>
 								import('@chainfuse/helpers/buffers').then(({ BufferHelpers }) =>
 									Promise.all(
-										rows.map(async (row) => ({
+										apiKeyRows.map(async (row) => ({
 											...row,
 											token_id: await BufferHelpers.uuidConvert(row.token_id),
 										})),
-									),
+									).then((apiKeyRows) => ({ apiKeyRows, keyringRows })),
 								),
 							)
-							.then(([row]) => {
+							.then(({ apiKeyRows, keyringRows }) => {
+								const row = apiKeyRows[0];
+
 								if (row) {
 									return import('~shared/types/d1/index.mjs')
 										.then(
@@ -101,9 +123,27 @@ app.openapi(route, (c) => {
 													expires: row.expires,
 													expired: new Date(row.expires) < new Date(),
 													lastModified: row.c_time,
-													keyringsPermission: Permissions[c.var.globalPermissions!.r_keyrings],
-													apikeysPermission: Permissions[c.var.globalPermissions!.r_apikeys],
-												}) satisfies z.infer<typeof apikeyOutput>,
+													apikeysPermission: Permissions[row.r_apikeys] as unknown as Permissions,
+													// It's the string version
+													keyringsPermission: Permissions[row.r_keyrings] as unknown as Permissions,
+													keyrings: keyringRows.reduce(
+														(acc, keyringRow) => {
+															if (keyringRow.keyring_name) {
+																acc[keyringRow.keyring_name] = {
+																	r_datakeys: Permissions[keyringRow.r_datakeys] as unknown as Permissions,
+																	r_encrypt: keyringRow.r_encrypt,
+																	r_decrypt: keyringRow.r_decrypt,
+																	r_rewrap: keyringRow.r_rewrap,
+																	r_sign: keyringRow.r_sign,
+																	r_verify: keyringRow.r_verify,
+																	r_hmac: keyringRow.r_hmac,
+																};
+															}
+															return acc;
+														},
+														{} as Record<string, any>,
+													),
+												}) satisfies z.output<typeof apikeyOutput>,
 										)
 										.then((result) => c.json(result, 200));
 								} else {


### PR DESCRIPTION
This pull request enhances the API key management functionality by introducing support for detailed permissions and keyring associations. The changes primarily focus on improving the `list` and `specific` API endpoints to include keyring-related data and permissions in their responses.

### Enhancements to API key management:

* **Support for Keyring Permissions in API Key Responses**:
  - Updated `api/src/v0/apikeys/list.mts` and `api/src/v0/apikeys/specific.mts` to include keyring permissions (`r_datakeys`, `r_encrypt`, `r_decrypt`, etc.) in the API key responses. This allows for more granular control and visibility of permissions associated with each API key. [[1]](diffhunk://#diff-5cda2971c2f1fa637592a9bf52afad5e71d49a1333ec24d5de4f4d45cc0e44a7R54-R135) [[2]](diffhunk://#diff-8c5adf906cacf2d9ccaf117f58d06d9dd50bad8d92629bd37a22db681c8f16c4R78-R113) [[3]](diffhunk://#diff-8c5adf906cacf2d9ccaf117f58d06d9dd50bad8d92629bd37a22db681c8f16c4L104-R146)

* **Integration of Keyring Data**:
  - Added logic to fetch and associate keyring data (`keyring_name`, `kr_id`) with API keys, enabling the grouping of permissions by API key ID in `list.mts` and `specific.mts`. [[1]](diffhunk://#diff-5cda2971c2f1fa637592a9bf52afad5e71d49a1333ec24d5de4f4d45cc0e44a7L42-R44) [[2]](diffhunk://#diff-8c5adf906cacf2d9ccaf117f58d06d9dd50bad8d92629bd37a22db681c8f16c4L65-R68)

### Code improvements:

* **Refactoring Permission Handling**:
  - Replaced global permission references with row-specific permissions (`r_apikeys`, `r_keyrings`) to improve accuracy and reduce reliance on global variables. [[1]](diffhunk://#diff-5cda2971c2f1fa637592a9bf52afad5e71d49a1333ec24d5de4f4d45cc0e44a7R54-R135) [[2]](diffhunk://#diff-8c5adf906cacf2d9ccaf117f58d06d9dd50bad8d92629bd37a22db681c8f16c4L104-R146)

* **Enhanced Type Usage**:
  - Imported and utilized the `Permissions` type from `~shared/types/d1/index.mjs` to ensure type safety and consistency in permission-related operations. [[1]](diffhunk://#diff-5cda2971c2f1fa637592a9bf52afad5e71d49a1333ec24d5de4f4d45cc0e44a7R4) [[2]](diffhunk://#diff-8c5adf906cacf2d9ccaf117f58d06d9dd50bad8d92629bd37a22db681c8f16c4R4)