### PR TITLE
Rotate api key

### DIFF
--- a/api/src/v0/apikeys/index.mts
+++ b/api/src/v0/apikeys/index.mts
@@ -3,6 +3,7 @@ import type { ContextVariables, EnvVars } from '~/types.mjs';
 import create from '~/v0/apikeys/create.mjs';
 import deleteRoute from '~/v0/apikeys/delete.mjs';
 import list from '~/v0/apikeys/list.mjs';
+import rotate from '~/v0/apikeys/rotate.mjs';
 import specific from '~/v0/apikeys/specific.mjs';
 
 const app = new OpenAPIHono<{ Bindings: EnvVars; Variables: ContextVariables }>();
@@ -11,5 +12,6 @@ app.route('/', create);
 app.route('/', list);
 app.route('/:token_id', specific);
 app.route('/:token_id', deleteRoute);
+app.route('/:token_id', rotate);
 
 export default app;

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -95,30 +95,23 @@ app.openapi(route, async (c) => {
 	// Set default expiration if not provided (90 days from now)
 	const expires = body.expires ? new Date(body.expires) : new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
 
-	try {
-		const ak_id = await BufferHelpers.uuidConvert(token_id);
+	const ak_id = await BufferHelpers.uuidConvert(token_id);
 
-		// First, verify the API key exists
-		const rows = await c.var
-			.t_db()
-			.select({
-				ak_id: api_keys.ak_id,
-				name: api_keys.name,
-				r_apikeys: api_keys.r_apikeys,
-				r_keyrings: api_keys.r_keyrings,
-				b_time: api_keys.b_time,
-				c_time: api_keys.c_time,
-			})
-			.from(api_keys)
-			.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
-			.limit(1);
+	// First, verify the API key exists
+	const [row] = await c.var
+		.t_db()
+		.select({
+			name: api_keys.name,
+			r_apikeys: api_keys.r_apikeys,
+			r_keyrings: api_keys.r_keyrings,
+			b_time: api_keys.b_time,
+			c_time: api_keys.c_time,
+		})
+		.from(api_keys)
+		.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
+		.limit(1);
 
-		if (rows.length === 0) {
-			return c.json({ error: 'API key not found' }, 404);
-		}
-
-		const existingKey = rows[0]!;
-
+	if (row) {
 		// Generate new API key secret
 		const ak_secret = await CryptoHelpers.secretBytes(512 / 8);
 		const [ak_secret_base64url, ak_secret_hash] = await Promise.all([
@@ -162,23 +155,22 @@ app.openapi(route, async (c) => {
 
 		// Return the rotated API key details including the new token
 		const response = {
-			created: existingKey.b_time,
+			created: row.b_time,
 			expired: expires < new Date(),
 			expires: expires.toISOString() as ISODateString,
 			lastModified: updatedRow.m_time,
-			lastRotation: existingKey.c_time,
-			name: existingKey.name,
+			lastRotation: row.c_time,
+			name: row.name,
 			token,
 			token_id: ak_id.base64url,
-			apikeysPermission: Permissions[existingKey.r_apikeys] as unknown as Permissions,
-			keyringsPermission: Permissions[existingKey.r_keyrings] as unknown as Permissions,
+			apikeysPermission: Permissions[row.r_apikeys] as unknown as Permissions,
+			keyringsPermission: Permissions[row.r_keyrings] as unknown as Permissions,
 			keyrings: {}, // Note: This endpoint doesn't return keyring permissions for simplicity
 		};
 
 		return c.json(response, 200);
-	} catch (error) {
-		console.error('Failed to rotate API key:', error);
-		return c.json({ error: 'Failed to rotate API key' }, 500);
+	} else {
+		return c.json({ error: 'API key not found' }, 404);
 	}
 });
 

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -4,7 +4,7 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { eq, sql } from 'drizzle-orm/sql';
 import { bearerAuth } from 'hono/bearer-auth';
 import { Buffer } from 'node:buffer';
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import type { ContextVariables, EnvVars } from '~/types.mjs';
 import { apikeyEditable, createApikeyOutput } from '~/v0/apikeys/shared.mjs';
 import { APITags } from '~/v0/extras.mjs';
@@ -97,24 +97,6 @@ app.openapi(route, async (c) => {
 
 	try {
 		const ak_id = await BufferHelpers.uuidConvert(token_id);
-
-		const hasPermission = (() => {
-			// Check if user has rotate permissions for API keys (Admin level)
-			if (c.var.globalPermissions?.r_apikeys === Permissions.Admin) {
-				return true;
-			}
-
-			const incomingBuffer = Buffer.from(ak_id.blob);
-			const originalBuffer = Buffer.from(c.var.ak_id.blob);
-
-			// Or if they're rotating their own key and have Write permissions
-			const isSameKey = timingSafeEqual(incomingBuffer, originalBuffer) && incomingBuffer.byteLength === originalBuffer.byteLength;
-			return isSameKey && c.var.globalPermissions?.r_apikeys && c.var.globalPermissions.r_apikeys >= Permissions.Write;
-		})();
-
-		if (!hasPermission) {
-			return c.json({ error: 'Insufficient permissions to rotate API keys' }, 403);
-		}
 
 		// First, verify the API key exists
 		const rows = await c.var

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -1,0 +1,203 @@
+import { BufferHelpers } from '@chainfuse/helpers/buffers';
+import { CryptoHelpers } from '@chainfuse/helpers/crypto';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
+import { eq, sql } from 'drizzle-orm/sql';
+import { bearerAuth } from 'hono/bearer-auth';
+import { Buffer } from 'node:buffer';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { ContextVariables, EnvVars } from '~/types.mjs';
+import { apikeyEditable, createApikeyOutput } from '~/v0/apikeys/shared.mjs';
+import { APITags } from '~/v0/extras.mjs';
+import { api_keys_tenants } from '~shared/db-preview/schemas/root';
+import { api_keys } from '~shared/db-preview/schemas/tenant';
+import { ApiKeyVersions } from '~shared/types/bw/index.mjs';
+import { Permissions, type ISODateString } from '~shared/types/d1/index.mjs';
+
+const app = new OpenAPIHono<{ Bindings: EnvVars; Variables: ContextVariables }>();
+
+app.use(
+	'*',
+	bearerAuth({
+		/**
+		 * Use sha512 (default uses sha256)
+		 * Use node crypto for optimization
+		 */
+		hashFunction: (data: string) => createHash('sha512').update(data).digest('hex'),
+		verifyToken: (token, c) => import('~/base.mjs').then(({ verifyToken }) => verifyToken(token, c)),
+	}),
+);
+
+export const route = createRoute({
+	tags: [APITags['API Key Management']],
+	method: 'put',
+	path: '/',
+	description: 'Rotate an API key by generating a new secret and optionally updating expiration.',
+	request: {
+		params: z.object({
+			token_id: createApikeyOutput.shape.token_id,
+		}),
+		body: {
+			content: {
+				'application/json': {
+					schema: z.object({
+						expires: apikeyEditable.shape.expires,
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				'application/json': {
+					schema: createApikeyOutput,
+				},
+			},
+			description: 'API key rotated successfully.',
+		},
+		403: {
+			content: {
+				'application/json': {
+					schema: z.object({
+						error: z.string(),
+					}),
+				},
+			},
+			description: 'Insufficient permissions.',
+		},
+		404: {
+			content: {
+				'application/json': {
+					schema: z.object({
+						error: z.string(),
+					}),
+				},
+			},
+			description: 'API key not found.',
+		},
+		500: {
+			content: {
+				'application/json': {
+					schema: z.object({
+						error: z.string(),
+					}),
+				},
+			},
+			description: 'Internal server error.',
+		},
+	},
+});
+
+app.openapi(route, async (c) => {
+	const { token_id } = c.req.valid('param');
+	const body = c.req.valid('json');
+
+	// Set default expiration if not provided (90 days from now)
+	const expires = body.expires ? new Date(body.expires) : new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
+
+	try {
+		const ak_id = await BufferHelpers.uuidConvert(token_id);
+
+		const hasPermission = (() => {
+			// Check if user has rotate permissions for API keys (Admin level)
+			if (c.var.globalPermissions?.r_apikeys === Permissions.Admin) {
+				return true;
+			}
+
+			const incomingBuffer = Buffer.from(ak_id.blob);
+			const originalBuffer = Buffer.from(c.var.ak_id.blob);
+
+			// Or if they're rotating their own key and have Write permissions
+			const isSameKey = timingSafeEqual(incomingBuffer, originalBuffer) && incomingBuffer.byteLength === originalBuffer.byteLength;
+			return isSameKey && c.var.globalPermissions?.r_apikeys && c.var.globalPermissions.r_apikeys >= Permissions.Write;
+		})();
+
+		if (!hasPermission) {
+			return c.json({ error: 'Insufficient permissions to rotate API keys' }, 403);
+		}
+
+		// First, verify the API key exists
+		const rows = await c.var
+			.t_db()
+			.select({
+				ak_id: api_keys.ak_id,
+				name: api_keys.name,
+				r_apikeys: api_keys.r_apikeys,
+				r_keyrings: api_keys.r_keyrings,
+				b_time: api_keys.b_time,
+				c_time: api_keys.c_time,
+			})
+			.from(api_keys)
+			.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
+			.limit(1);
+
+		if (rows.length === 0) {
+			return c.json({ error: 'API key not found' }, 404);
+		}
+
+		const existingKey = rows[0]!;
+
+		// Generate new API key secret
+		const ak_secret = await CryptoHelpers.secretBytes(512 / 8);
+		const [ak_secret_base64url, ak_secret_hash] = await Promise.all([
+			// Convert to format for user response
+			BufferHelpers.bufferToBase64(ak_secret.buffer, true),
+			// Hash to store in db
+			CryptoHelpers.getHash('SHA-512', ak_secret.buffer),
+		]);
+
+		// Create the new bearer token
+		const token = [ApiKeyVersions['512base64urlSha512'], ak_id.base64url, ak_secret_base64url].join('.');
+
+		// Update both databases in parallel
+		const [, [updatedRow]] = await Promise.all([
+			// Update root database (expires only)
+			c.var
+				.r_db()
+				.update(api_keys_tenants)
+				.set({
+					expires: expires.toISOString() as ISODateString,
+				})
+				.where(sql`${api_keys_tenants.ak_id} = unhex(${ak_id.hex}) AND ${api_keys_tenants.t_id} = unhex(${c.var.t_id.hex})`),
+			// Update tenant database (hash, expires, m_time auto-updates)
+			c.var
+				.t_db()
+				.update(api_keys)
+				.set({
+					hash: sql<Buffer>`unhex(${ak_secret_hash})`,
+					expires: expires.toISOString() as ISODateString,
+					// m_time will be automatically updated by the $onUpdate trigger
+				})
+				.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
+				.returning({
+					m_time: api_keys.m_time,
+				}),
+		]);
+
+		if (!updatedRow) {
+			return c.json({ error: 'Failed to update API key' }, 500);
+		}
+
+		// Return the rotated API key details including the new token
+		const response = {
+			created: existingKey.b_time,
+			expired: expires < new Date(),
+			expires: expires.toISOString() as ISODateString,
+			lastModified: updatedRow.m_time,
+			lastRotation: existingKey.c_time,
+			name: existingKey.name,
+			token,
+			token_id: ak_id.base64url,
+			apikeysPermission: Permissions[existingKey.r_apikeys] as unknown as Permissions,
+			keyringsPermission: Permissions[existingKey.r_keyrings] as unknown as Permissions,
+			keyrings: {}, // Note: This endpoint doesn't return keyring permissions for simplicity
+		};
+
+		return c.json(response, 200);
+	} catch (error) {
+		console.error('Failed to rotate API key:', error);
+		return c.json({ error: 'Failed to rotate API key' }, 500);
+	}
+});
+
+export default app;

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -111,16 +111,14 @@ app.openapi(route, async (c) => {
 
 		if ((row?.count ?? 0) > 0) {
 			// Generate new API key secret
-			const ak_secret = await CryptoHelpers.secretBytes(512 / 8);
-			const [ak_secret_base64url, ak_secret_hash] = await Promise.all([
-				// Convert to format for user response
-				BufferHelpers.bufferToBase64(ak_secret.buffer, true),
-				// Hash to store in db
-				CryptoHelpers.getHash('SHA-512', ak_secret.buffer),
-			]);
-
-			// Create the new bearer token
-			const token = [ApiKeyVersions['512base64urlSha512'], ak_id.base64url, ak_secret_base64url].join('.');
+			const { ak_secret_base64url, ak_secret_hash } = await CryptoHelpers.secretBytes(512 / 8).then((ak_secret) =>
+				Promise.all([
+					// Convert to format for user response
+					BufferHelpers.bufferToBase64(ak_secret.buffer, true),
+					// Hash to store in db
+					CryptoHelpers.getHash('SHA-512', ak_secret.buffer),
+				]).then(([ak_secret_base64url, ak_secret_hash]) => ({ ak_secret_base64url, ak_secret_hash })),
+			);
 
 			// Update both databases in parallel
 			const [, [updatedRow]] = await Promise.all([

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -1,7 +1,7 @@
 import { BufferHelpers } from '@chainfuse/helpers/buffers';
 import { CryptoHelpers } from '@chainfuse/helpers/crypto';
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
-import { eq, sql } from 'drizzle-orm/sql';
+import { count, eq, sql } from 'drizzle-orm/sql';
 import { bearerAuth } from 'hono/bearer-auth';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
@@ -95,82 +95,83 @@ app.openapi(route, async (c) => {
 	// Set default expiration if not provided (90 days from now)
 	const expires = body.expires ? new Date(body.expires) : new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
 
-	const ak_id = await BufferHelpers.uuidConvert(token_id);
+	// Check permissions first
+	if ((c.var.globalPermissions?.r_apikeys ?? Permissions.None) >= Permissions.Write) {
+		const ak_id = await BufferHelpers.uuidConvert(token_id);
 
-	// First, verify the API key exists
-	const [row] = await c.var
-		.t_db()
-		.select({
-			name: api_keys.name,
-			r_apikeys: api_keys.r_apikeys,
-			r_keyrings: api_keys.r_keyrings,
-			b_time: api_keys.b_time,
-			c_time: api_keys.c_time,
-		})
-		.from(api_keys)
-		.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
-		.limit(1);
+		// First, verify the API key exists
+		const [row] = await c.var
+			.t_db()
+			.select({
+				count: count(),
+			})
+			.from(api_keys)
+			.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
+			.limit(1);
 
-	if (row) {
-		// Generate new API key secret
-		const ak_secret = await CryptoHelpers.secretBytes(512 / 8);
-		const [ak_secret_base64url, ak_secret_hash] = await Promise.all([
-			// Convert to format for user response
-			BufferHelpers.bufferToBase64(ak_secret.buffer, true),
-			// Hash to store in db
-			CryptoHelpers.getHash('SHA-512', ak_secret.buffer),
-		]);
+		if ((row?.count ?? 0) > 0) {
+			// Generate new API key secret
+			const ak_secret = await CryptoHelpers.secretBytes(512 / 8);
+			const [ak_secret_base64url, ak_secret_hash] = await Promise.all([
+				// Convert to format for user response
+				BufferHelpers.bufferToBase64(ak_secret.buffer, true),
+				// Hash to store in db
+				CryptoHelpers.getHash('SHA-512', ak_secret.buffer),
+			]);
 
-		// Create the new bearer token
-		const token = [ApiKeyVersions['512base64urlSha512'], ak_id.base64url, ak_secret_base64url].join('.');
+			// Create the new bearer token
+			const token = [ApiKeyVersions['512base64urlSha512'], ak_id.base64url, ak_secret_base64url].join('.');
 
-		// Update both databases in parallel
-		const [, [updatedRow]] = await Promise.all([
-			// Update root database (expires only)
-			c.var
-				.r_db()
-				.update(api_keys_tenants)
-				.set({
-					expires: expires.toISOString() as ISODateString,
-				})
-				.where(sql`${api_keys_tenants.ak_id} = unhex(${ak_id.hex}) AND ${api_keys_tenants.t_id} = unhex(${c.var.t_id.hex})`),
-			// Update tenant database (hash, expires, m_time auto-updates)
-			c.var
-				.t_db()
-				.update(api_keys)
-				.set({
-					hash: sql<Buffer>`unhex(${ak_secret_hash})`,
-					expires: expires.toISOString() as ISODateString,
-					// m_time will be automatically updated by the $onUpdate trigger
-				})
-				.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
-				.returning({
-					m_time: api_keys.m_time,
-				}),
-		]);
+			// Update both databases in parallel
+			const [, [updatedRow]] = await Promise.all([
+				// Update root database (expires only)
+				c.var
+					.r_db()
+					.update(api_keys_tenants)
+					.set({
+						expires: expires.toISOString() as ISODateString,
+					})
+					.where(sql`${api_keys_tenants.ak_id} = unhex(${ak_id.hex}) AND ${api_keys_tenants.t_id} = unhex(${c.var.t_id.hex})`),
+				// Update tenant database (hash, expires, m_time auto-updates)
+				c.var
+					.t_db()
+					.update(api_keys)
+					.set({
+						hash: sql<Buffer>`unhex(${ak_secret_hash})`,
+						expires: expires.toISOString() as ISODateString,
+						// m_time will be automatically updated by the $onUpdate trigger
+					})
+					.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
+					.returning({
+						m_time: api_keys.m_time,
+					}),
+			]);
 
-		if (!updatedRow) {
-			return c.json({ error: 'Failed to update API key' }, 500);
+			if (!updatedRow) {
+				return c.json({ error: 'Failed to update API key' }, 500);
+			}
+
+			// Return the rotated API key details including the new token
+			const response = {
+				created: row.b_time,
+				expired: expires < new Date(),
+				expires: expires.toISOString() as ISODateString,
+				lastModified: updatedRow.m_time,
+				lastRotation: row.c_time,
+				name: row.name,
+				token,
+				token_id: ak_id.base64url,
+				apikeysPermission: Permissions[row.r_apikeys] as unknown as Permissions,
+				keyringsPermission: Permissions[row.r_keyrings] as unknown as Permissions,
+				keyrings: {}, // Note: This endpoint doesn't return keyring permissions for simplicity
+			};
+
+			return c.json(response, 200);
+		} else {
+			return c.json({ error: 'API key not found' }, 404);
 		}
-
-		// Return the rotated API key details including the new token
-		const response = {
-			created: row.b_time,
-			expired: expires < new Date(),
-			expires: expires.toISOString() as ISODateString,
-			lastModified: updatedRow.m_time,
-			lastRotation: row.c_time,
-			name: row.name,
-			token,
-			token_id: ak_id.base64url,
-			apikeysPermission: Permissions[row.r_apikeys] as unknown as Permissions,
-			keyringsPermission: Permissions[row.r_keyrings] as unknown as Permissions,
-			keyrings: {}, // Note: This endpoint doesn't return keyring permissions for simplicity
-		};
-
-		return c.json(response, 200);
 	} else {
-		return c.json({ error: 'API key not found' }, 404);
+		return c.json({ error: 'Insufficient permissions to rotate API keys' }, 403);
 	}
 });
 

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -137,7 +137,7 @@ app.openapi(route, async (c) => {
 					.set({
 						hash: sql<Buffer>`unhex(${ak_secret_hash})`,
 						expires: expires.toISOString() as ISODateString,
-						// m_time will be automatically updated by the $onUpdate trigger
+						m_time: new Date().toISOString() as ISODateString,
 					})
 					.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
 					.returning({

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -1,7 +1,7 @@
 import { BufferHelpers } from '@chainfuse/helpers/buffers';
 import { CryptoHelpers } from '@chainfuse/helpers/crypto';
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
-import { count, eq, sql } from 'drizzle-orm/sql';
+import { and, count, eq, sql } from 'drizzle-orm/sql';
 import { bearerAuth } from 'hono/bearer-auth';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
@@ -121,15 +121,7 @@ app.openapi(route, async (c) => {
 			);
 
 			// Update both databases in parallel
-			const [, [updatedRow]] = await Promise.all([
-				// Update root database (expires only)
-				c.var
-					.r_db()
-					.update(api_keys_tenants)
-					.set({
-						expires: expires.toISOString() as ISODateString,
-					})
-					.where(sql`${api_keys_tenants.ak_id} = unhex(${ak_id.hex}) AND ${api_keys_tenants.t_id} = unhex(${c.var.t_id.hex})`),
+			return Promise.all([
 				// Update tenant database (hash, expires, m_time auto-updates)
 				c.var
 					.t_db()
@@ -139,32 +131,27 @@ app.openapi(route, async (c) => {
 						expires: expires.toISOString() as ISODateString,
 						m_time: new Date().toISOString() as ISODateString,
 					})
-					.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`))
-					.returning({
-						m_time: api_keys.m_time,
-					}),
-			]);
-
-			if (!updatedRow) {
-				return c.json({ error: 'Failed to update API key' }, 500);
-			}
-
-			// Return the rotated API key details including the new token
-			const response = {
-				created: row.b_time,
-				expired: expires < new Date(),
-				expires: expires.toISOString() as ISODateString,
-				lastModified: updatedRow.m_time,
-				lastRotation: row.c_time,
-				name: row.name,
-				token,
-				token_id: ak_id.base64url,
-				apikeysPermission: Permissions[row.r_apikeys] as unknown as Permissions,
-				keyringsPermission: Permissions[row.r_keyrings] as unknown as Permissions,
-				keyrings: {}, // Note: This endpoint doesn't return keyring permissions for simplicity
-			};
-
-			return c.json(response, 200);
+					.where(eq(api_keys.ak_id, sql<Buffer>`unhex(${ak_id.hex})`)),
+				// Update root database (expires only)
+				c.var
+					.r_db()
+					.update(api_keys_tenants)
+					.set({
+						expires: expires.toISOString() as ISODateString,
+					})
+					.where(and(eq(api_keys_tenants.ak_id, sql<Buffer>`unhex(${ak_id.hex})`), eq(api_keys_tenants.t_id, sql<Buffer>`unhex(${c.var.t_id.hex})`))),
+			])
+				.then(() =>
+					c.json(
+						{
+							token_id: ak_id.base64url,
+							expires: expires.toISOString() as ISODateString,
+							token: [ApiKeyVersions['512base64urlSha512'], ak_id.base64url, ak_secret_base64url].join('.'),
+						},
+						200,
+					),
+				)
+				.catch(() => c.json({ error: 'Failed to update API key' }, 500));
 		} else {
 			return c.json({ error: 'API key not found' }, 404);
 		}

--- a/api/src/v0/apikeys/rotate.mts
+++ b/api/src/v0/apikeys/rotate.mts
@@ -93,7 +93,13 @@ app.openapi(route, async (c) => {
 	const body = c.req.valid('json');
 
 	// Set default expiration if not provided (90 days from now)
-	const expires = body.expires ? new Date(body.expires) : new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
+	const expires = body.expires
+		? new Date(body.expires)
+		: new Date(
+				Date.now() +
+					// days * hours * minutes * seconds * milliseconds
+					90 * 24 * 60 * 60 * 1000,
+			);
 
 	// Check permissions first
 	if ((c.var.globalPermissions?.r_apikeys ?? Permissions.None) >= Permissions.Write) {


### PR DESCRIPTION
This pull request introduces a new API endpoint for rotating API keys, enhancing the API key management capabilities. The main changes include the addition of the `rotate` route to the API key routes and the implementation of the logic for securely rotating an API key, including permission checks and updates to relevant databases.

**API Key Rotation Feature:**

* Added a new `rotate` route to the API key management endpoints, allowing users to rotate an existing API key via a `PUT` request to `/:token_id`. [[1]](diffhunk://#diff-cb5d2425dfabe0a56c15f1118b0e106fc6991f68f4a8e7272443b47a1cf98183R6) [[2]](diffhunk://#diff-cb5d2425dfabe0a56c15f1118b0e106fc6991f68f4a8e7272443b47a1cf98183R15)
* Implemented the API key rotation logic in `rotate.mts`, including:
  - Secure generation of a new API key secret and its hash.
  - Permission checks to ensure only authorized users can rotate API keys.
  - Updating both tenant and root databases with the new secret and expiration date.
  - Comprehensive error handling for permission issues, missing keys, and internal errors.
* Defined OpenAPI documentation for the new endpoint, specifying request parameters, body schema, and possible responses.